### PR TITLE
Add fluent-plugin-splunkhec

### DIFF
--- a/common-install.sh
+++ b/common-install.sh
@@ -54,7 +54,8 @@ gem install -N --conservative --minimal-deps --no-document \
   fluent-plugin-rewrite-tag-filter \
   fluent-plugin-secure-forward \
   'fluent-plugin-remote_syslog:<1.0.0' \
-  fluent-plugin-splunk-ex
+  fluent-plugin-splunk-ex \
+  fluent-plugin-splunkhec
 
 # set up directores so that group 0 can have access like specified in
 # https://docs.openshift.com/container-platform/3.7/creating_images/guidelines.html


### PR DESCRIPTION
Added the Splunk HTTP Event Collector output plugin to list of plugins. The splunk-ex plugin is problematic for a few reasons; it's using a raw protocol, requires a specific ingest port, and is unsuitable for highly-available Splunk deployments.

To use the splunkhec plugin, an API token needs to be created on Splunk without indexer acknowledgement. The following parameters need to be added or replaced to specify the plugin and token for the Splunk API:

```
    -p P_TARGET_TYPE="splunkhec" \
    -p P_ADDITIONAL_OPTS="token <token_value>"
```